### PR TITLE
Namespace with numbers

### DIFF
--- a/src/Leprechaun.Tests/MetadataGeneration/StandardTypeNameGeneratorTests.cs
+++ b/src/Leprechaun.Tests/MetadataGeneration/StandardTypeNameGeneratorTests.cs
@@ -9,7 +9,7 @@ namespace Leprechaun.Tests.MetadataGeneration
 		[Theory,
 			InlineData("/Foo", "/Foo/Bar", "Bar"),
 			InlineData("/Foo/Bar", "/Foo/Bar/Baz/Quux", "Baz.Quux"),
-			InlineData("/Foo/Bar", "/Foo/Bar/Baz/9Foo/Quux", "Baz._9Foo.Quux"),
+			InlineData("/Foo/Bar", "/Foo/Bar/Baz/9Foo9/Quux", "Baz._9Foo9.Quux"),
 			InlineData("/Foo", "/Foo/Name Transform.Test", "NameTransform.Test"),
 			InlineData("/Foo", "/Foo/Name Transform", "NameTransform")]
 		public void GetFullTypeName_ShouldPerformAsExpected(string rootNamespace, string fullPath, string expected)

--- a/src/Leprechaun.Tests/MetadataGeneration/StandardTypeNameGeneratorTests.cs
+++ b/src/Leprechaun.Tests/MetadataGeneration/StandardTypeNameGeneratorTests.cs
@@ -9,6 +9,7 @@ namespace Leprechaun.Tests.MetadataGeneration
 		[Theory,
 			InlineData("/Foo", "/Foo/Bar", "Bar"),
 			InlineData("/Foo/Bar", "/Foo/Bar/Baz/Quux", "Baz.Quux"),
+			InlineData("/Foo/Bar", "/Foo/Bar/Baz/9Foo/Quux", "Baz._9Foo.Quux"),
 			InlineData("/Foo", "/Foo/Name Transform.Test", "NameTransform.Test"),
 			InlineData("/Foo", "/Foo/Name Transform", "NameTransform")]
 		public void GetFullTypeName_ShouldPerformAsExpected(string rootNamespace, string fullPath, string expected)
@@ -23,6 +24,7 @@ namespace Leprechaun.Tests.MetadataGeneration
 			InlineData("9Foo9", "_9Foo9"), // identifier cannot begin with number
 			InlineData("Field Name", "FieldName"),
 			InlineData("field_name", "FieldName"),
+			InlineData("field_name_id", "FieldNameId"),
 			InlineData("Field.Name", "Field.Name")]
 		public void ConvertToIdentifier_ShouldPerformAsExpected(string input, string expected)
 		{

--- a/src/Leprechaun/MetadataGeneration/StandardTypeNameGenerator.cs
+++ b/src/Leprechaun/MetadataGeneration/StandardTypeNameGenerator.cs
@@ -66,7 +66,7 @@ namespace Leprechaun.MetadataGeneration
 		public virtual string ConvertToIdentifier(string name)
 		{
 			// Desnakeify case if it exists (e.g. foo_bar -> "foo bar")
-			name = name.Replace("_", " ");
+			name = Regex.Replace(name, @"(\w)_(\w)", "$1 $2");
 
 			// Uppercase any non-capitalized words (e.g. 'lord flowers' -> 'Lord Flowers')
 			// this makes identifiers Pascal Case as .NET expects


### PR DESCRIPTION
I was runnin ginto issues with namespaces containing numbers, while the fields were allowed to have them, the namespaces lost its corrections in the snake_case handler code.