### PR TITLE
Add the global scope to namespaces to inherited interfaces for friending

### DIFF
--- a/src/Leprechaun.CodeGen.Roslyn/Scripts/Synthesis.csx
+++ b/src/Leprechaun.CodeGen.Roslyn/Scripts/Synthesis.csx
@@ -94,7 +94,7 @@ public string GetBaseInterfaces(TemplateCodeGenerationMetadata template)
 
 	foreach(var baseTemplate in template.BaseTemplates) 
 	{
-		bases.Add($"{baseTemplate.Namespace}.I{baseTemplate.CodeName}Item");
+		bases.Add($"global::{baseTemplate.Namespace}.I{baseTemplate.CodeName}Item");
 	}
 
 	if (bases.Count == 0)


### PR DESCRIPTION
When inheriting from a base template in another project the compiler can't see the namespace of the friend.

For example, if you have a base template in the Feature layer that is inherited by a project in the Project layer when you try and compile you get namespace not found errors in the Project layer model.

The Synthesis generator solves this by adding the global:: scope to the namespace.  Updated the template to include this.