### PR TITLE
Add the global scope to system namespaces that are hidden when buildi…

### DIFF
--- a/src/Leprechaun.CodeGen.Roslyn/Scripts/Synthesis.csx
+++ b/src/Leprechaun.CodeGen.Roslyn/Scripts/Synthesis.csx
@@ -14,8 +14,8 @@ namespace {template.Namespace}
 	using global::Sitecore.ContentSearch;
 	using global::Sitecore.Data;
 	using global::Sitecore.Data.Items;
-	using System.CodeDom.Compiler;
-	using System.Collections.Generic;
+	using global::System.CodeDom.Compiler;
+	using global::System.Collections.Generic;
 	using Synthesis;
 	using Synthesis.FieldTypes;
 	using Synthesis.FieldTypes.Interfaces;


### PR DESCRIPTION
…ng items with System in the path

When building items that have a folder named System in the path it is hiding the system namespaces.  Ran into this issue specifically with creating objects for Media item templates.

Resolved the issue by adding the global namespace to the two system using statements.