### PR TITLE
Adding support for Helix tenant folder variable replacement.

### DIFF
--- a/src/Leprechaun.Console/Leprechaun.Console.csproj
+++ b/src/Leprechaun.Console/Leprechaun.Console.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Variables\ConfigPathVariableReplacer.cs" />
     <Compile Include="Variables\ConfigurationNameVariablesReplacer.cs" />
     <Compile Include="Variables\HelixConventionVariablesReplacer.cs" />
+    <Compile Include="Variables\MultiTenantHelixConventionVariablesReplacer.cs" />
     <Compile Include="Watcher.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Leprechaun.Console/Program.cs
+++ b/src/Leprechaun.Console/Program.cs
@@ -144,6 +144,7 @@ namespace Leprechaun.Console
 			var replacer = new ChainedVariablesReplacer(
 				new ConfigurationNameVariablesReplacer(),
 				new HelixConventionVariablesReplacer(),
+				new MultiTenantHelixConventionVariablesReplacer(),
 				new ConfigPathVariableReplacer(Path.GetDirectoryName(args.ConfigFilePath)));
 
 			var configObject = new LeprechaunConfigurationBuilder(replacer, config.DocumentElement["configurations"], config.DocumentElement["defaults"], config.DocumentElement["shared"], args.ConfigFilePath, new ConfigurationImportPathResolver(new ConsoleLogger()));

--- a/src/Leprechaun.Console/Variables/MultiTenantHelixConventionVariablesReplacer.cs
+++ b/src/Leprechaun.Console/Variables/MultiTenantHelixConventionVariablesReplacer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Leprechaun.Console.Variables
+{
+	public class MultiTenantHelixConventionVariablesReplacer : HelixConventionVariablesReplacer
+	{
+		public override Dictionary<string, string> GetVariables(string name)
+		{
+			var pieces = name.Split('.');
+
+			if (pieces.Length < 2) return new Dictionary<string, string>();
+			if (pieces.Length == 2) return base.GetVariables(name);
+
+			var vars = new Dictionary<string, string>()
+			{
+				{"tenant", pieces[0]},
+				{"layer", pieces[1]},
+				{"module", pieces[2]}
+			};
+
+			if (pieces.Length >= 4)
+			{
+				vars.Add("moduleConfigName", pieces[3]);
+			}
+			else
+			{
+				// fallback if no third level name is used but variable is defined
+				vars.Add("moduleConfigName", "Dev");
+			}
+
+			return vars;
+		}
+	}
+}


### PR DESCRIPTION
Created a class that supports another token for a tenant folder. If the tenant folder is not detected, it will fall back to the base behavior.

Using this class allows us to generate code files for Helix modules in tenant folders and not in tenant folders within the same solution.