### PR TITLE
Remove hardcoded namespace part in glass mapper generation.

### DIFF
--- a/src/Leprechaun.CodeGen.Roslyn/Scripts/GlassMapper.csx
+++ b/src/Leprechaun.CodeGen.Roslyn/Scripts/GlassMapper.csx
@@ -24,7 +24,7 @@ public string RenderTemplates()
     foreach (var template in Templates)
     {
         localCode.AppendLine($@"
-namespace {template.Namespace}.Models
+namespace {template.Namespace}
 {{
     using System;
     using System.CodeDom.Compiler;


### PR DESCRIPTION
Remove hardcoded namespace part, which causes errors when generating glass models for inherited templates.
It's better to add ".Models" suffix in <templatePredicate rootNamespace="" in the config file instead. 