### PR TITLE
Add generatedcode attribute in template

### DIFF
--- a/src/Leprechaun.CodeGen.Roslyn/Scripts/GlassMapper.csx
+++ b/src/Leprechaun.CodeGen.Roslyn/Scripts/GlassMapper.csx
@@ -33,10 +33,12 @@ namespace {template.Namespace}.Models
     using Glass.Mapper.Sc.Configuration.Attributes;
     using Glass.Mapper.Sc.Fields;
     using global::Sitecore.Data;
+	using System.CodeDom.Compiler;
 
     /// <summary>Controls the appearance of the inheriting template in site navigation.</summary>
     ///[RepresentsSitecoreTemplateAttribute(""{{{template.Id}}}"", """", ""{ConfigurationName}"")]
     [SitecoreType(TemplateId = {template.Namespace}.Constants.{template.CodeName}.TemplateIdString)]
+	[GeneratedCode(""Leprechaun"", ""1.0.0.0"")]
     public partial interface I{template.CodeName} : {GetBaseInterfaces(template)}
     {{
         {RenderInterfaceFields(template)}
@@ -47,7 +49,9 @@ namespace {template.Namespace}.Models
 namespace {template.Namespace}.Constants
 {{
     using global::Sitecore.Data;
+	using System.CodeDom.Compiler;
 
+	[GeneratedCode(""Leprechaun"", ""1.0.0.0"")]
     public struct {template.CodeName}
     {{
         public const string TemplateIdString = ""{template.Id}"";

--- a/src/Leprechaun.CodeGen.Roslyn/Scripts/Habitat.csx
+++ b/src/Leprechaun.CodeGen.Roslyn/Scripts/Habitat.csx
@@ -49,7 +49,9 @@ Code.AppendLine($@"
 namespace {GenericRootNamespace}
 {{
 	using global::Sitecore.Data;
+	using System.CodeDom.Compiler;
 
+	[GeneratedCode(""leprechaun"", ""1.0.0.0"")]
 	public struct Templates
 	{{
 		{RenderTemplates()}

--- a/src/Leprechaun.CodeGen.Roslyn/Scripts/Habitat.csx
+++ b/src/Leprechaun.CodeGen.Roslyn/Scripts/Habitat.csx
@@ -51,7 +51,7 @@ namespace {GenericRootNamespace}
 	using global::Sitecore.Data;
 	using System.CodeDom.Compiler;
 
-	[GeneratedCode(""leprechaun"", ""1.0.0.0"")]
+	[GeneratedCode(""Leprechaun"", ""1.0.0.0"")]
 	public struct Templates
 	{{
 		{RenderTemplates()}

--- a/src/Leprechaun.CodeGen.Roslyn/Scripts/Synthesis.csx
+++ b/src/Leprechaun.CodeGen.Roslyn/Scripts/Synthesis.csx
@@ -21,15 +21,18 @@ namespace {template.Namespace}
 	using Synthesis.FieldTypes.Interfaces;
 	using Synthesis.Initializers;
 	using Synthesis.Synchronization;
+	using System.CodeDom.Compiler;	
 
 	/// <summary>Controls the appearance of the inheriting template in site navigation.</summary>
-	[RepresentsSitecoreTemplateAttribute(""{{{template.Id}}}"", """", ""{ConfigurationName}"")]
+	[RepresentsSitecoreTemplateAttribute(""{{{template.Id}}}"", """", ""{ConfigurationName}"")]	
+	[GeneratedCode(""Leprechaun"", ""1.0.0.0"")]
 	public interface I{template.CodeName}Item : {GetBaseInterfaces(template)}
 	{{
 		{RenderInterfaceFields(template)}
 	}}
 
 	/// <summary>Controls the appearance of the inheriting template in site navigation.</summary>
+	[GeneratedCode(""Leprechaun"", ""1.0.0.0"")]
 	public class {template.CodeName} : StandardTemplateItem, I{template.CodeName}Item
 	{{
 		public {template.CodeName}(Item innerItem) : base(innerItem)
@@ -52,6 +55,7 @@ namespace {template.Namespace}
 		{RenderFields(template)}
 	}}
 
+	[GeneratedCode(""Leprechaun"", ""1.0.0.0"")]
 	public class {template.CodeName}Initializer : ITemplateInitializer
 	{{
 		public ID InitializesTemplateId => new ID(""{{{template.Id}}}"");


### PR DESCRIPTION
To prevent code analyses errors/warning in generated template files a generatedcode attribute is needed.