### PR TITLE
Make all template field info fields available.

### DIFF
--- a/src/Leprechaun/Model/TemplateFieldCodeGenerationMetadata.cs
+++ b/src/Leprechaun/Model/TemplateFieldCodeGenerationMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Leprechaun.Model
@@ -31,6 +32,8 @@ namespace Leprechaun.Model
 		public virtual string Section => Field.Section;
 
 		public virtual int SortOrder => Field.SortOrder;
+
+        public virtual Dictionary<Guid, string> AllFields => Field.AllFields;
 
 		/// <summary>
 		/// A unique name for this template field, usable as a C# identifier (e.g. property name)

--- a/src/Leprechaun/Model/TemplateFieldInfo.cs
+++ b/src/Leprechaun/Model/TemplateFieldInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Leprechaun.Model
@@ -6,6 +7,11 @@ namespace Leprechaun.Model
 	[DebuggerDisplay("{Path} ({Id})")]
 	public class TemplateFieldInfo
 	{
+        public TemplateFieldInfo()
+        {
+            AllFields = new Dictionary<Guid, string>();
+		}
+
 		public Guid Id { get; set; }
 
 		public string Name { get; set; }
@@ -23,5 +29,7 @@ namespace Leprechaun.Model
 		public string Section { get; set; }
 
 		public int SortOrder { get; set; }
+
+		public Dictionary<Guid, string> AllFields { get; set; }
 	}
 }

--- a/src/Leprechaun/TemplateReaders/DataStoreTemplateReader.cs
+++ b/src/Leprechaun/TemplateReaders/DataStoreTemplateReader.cs
@@ -111,7 +111,8 @@ namespace Leprechaun.TemplateReaders
 						Section = section.Name,
 						SortOrder = GetFieldValueAsInt(field, SortOrderFieldId, 100),
 						Source = GetFieldValue(field, SourceFieldId, string.Empty),
-						Type = GetFieldValue(field, FieldTypeFieldId, string.Empty)
+						Type = GetFieldValue(field, FieldTypeFieldId, string.Empty),
+						AllFields = GetAllFields(field)
 					});
 				}
 			}
@@ -180,5 +181,42 @@ namespace Leprechaun.TemplateReaders
 		}
 
 		protected virtual ICollection<Guid> IgnoredBaseTemplateIds => new HashSet<Guid> { TemplateIDs.StandardTemplate.Guid, TemplateIDs.Folder.Guid };
+
+        protected virtual Dictionary<Guid, string> GetAllFields(IItemData item)
+        {
+			var allFields = new Dictionary<Guid, string>();
+
+            foreach (var field in item.SharedFields)
+            {
+                if (!allFields.ContainsKey(field.FieldId))
+                {
+                    allFields.Add(field.FieldId, field.Value);
+                }
+            }
+
+            foreach (var language in item.UnversionedFields)
+            {
+                foreach (var field in language.Fields)
+                {
+					if (!allFields.ContainsKey(field.FieldId))
+                    {
+                        allFields.Add(field.FieldId, field.Value);
+                    }
+				}
+            }
+
+            foreach (var version in item.Versions)
+            {
+                foreach (var field in version.Fields)
+                {
+					if (!allFields.ContainsKey(field.FieldId))
+                    {
+                        allFields.Add(field.FieldId, field.Value);
+                    }
+				}
+            }
+
+            return allFields;
+        }
 	}
 }


### PR DESCRIPTION
When adding custom fields to the template field those can't be accessed in the current version. This PR makes those fields available.

For example I've added a 'Do not auto generate' and 'Do not edit in Experience Editor' field:

![generate1](https://user-images.githubusercontent.com/5444597/63765258-f3c06f00-c8c8-11e9-85d0-d0c5f17bd265.jpg)

So per template field you can manage this:

![generate2](https://user-images.githubusercontent.com/5444597/63765338-1488c480-c8c9-11e9-81b1-fb7bbe884ade.jpg)

With this info available I made some changes to the GlassMapper.csx file:

```
public static readonly System.Guid DoNotAutoGenerateId = new System.Guid("{CA075FD6-5BDD-44E6-881F-74AE42568C44}");
public static readonly System.Guid DoNotEditInExperienceEditorId = new System.Guid("{97A75B68-9E59-4F97-84F7-AD9CC4D081B3}");

public string RenderInterfaceFields(TemplateCodeGenerationMetadata template)
{
    var localCode = new System.Text.StringBuilder();

    foreach (var field in template.OwnFields)
    {
        var autoGenerate = !field.AllFields.ContainsKey(DoNotAutoGenerateId) || field.AllFields[DoNotAutoGenerateId] != "1";
        var isEditable = !field.AllFields.ContainsKey(DoNotEditInExperienceEditorId) || field.AllFields[DoNotEditInExperienceEditorId] != "1";

        if (autoGenerate)
        {
        localCode.AppendLine($@"
        /// <summary>{field.HelpText}</summary>
        [SitecoreField(FieldId = {template.Namespace}.Constants.{template.CodeName}.Fields.{field.CodeName}IdString)]
        [ExperienceEditor(IsEditable = {isEditable.ToString().ToLower()})]
        public virtual {GetFieldType(field)} {field.CodeName} {{ get; set; }}");
        }
    }

    return localCode.ToString();
}
```
So by making custom field info also accessible you become much more flexible in creating your own custom GlassMapper.csx.

There are some more examples, but I will blog about those soon.