### PR TITLE
Issue #59 - Path on Mac OSX

### DIFF
--- a/src/Leprechaun.Tests/ConfigurationImportPathResolverTests.cs
+++ b/src/Leprechaun.Tests/ConfigurationImportPathResolverTests.cs
@@ -81,7 +81,7 @@ namespace Leprechaun.Tests
 		}
 
 		private string AbsoluteTestRoot => Path.Combine(Environment.CurrentDirectory, "ConfigurationImportPathResolverTests");
-		private string RelativeTestRoot => ".\\ConfigurationImportPathResolverTests";
+		private string RelativeTestRoot => $".{Path.DirectorySeparatorChar}ConfigurationImportPathResolverTests";
 		private string AbsolutePathToBarConfig => Path.Combine(AbsoluteTestRoot, "Directory2", "Bar.config");
 		private string AbsolutePathToFooConfig => Path.Combine(AbsoluteTestRoot, "Directory1", "Directory1.1", "Foo.config");
 

--- a/src/Leprechaun.Tests/Leprechaun.Tests.csproj
+++ b/src/Leprechaun.Tests/Leprechaun.Tests.csproj
@@ -80,6 +80,9 @@
     <PackageReference Include="xunit.core">
       <Version>2.3.1</Version>
     </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.4.5</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Leprechaun\Leprechaun.csproj" />

--- a/src/Leprechaun/Configuration/ConfigurationImportPathResolver.cs
+++ b/src/Leprechaun/Configuration/ConfigurationImportPathResolver.cs
@@ -21,7 +21,7 @@ namespace Leprechaun.Configuration
 		public virtual string[] ResolveImportPaths(string inputPath)
 		{
 			// normalize input path 
-			inputPath = inputPath.Replace('/', '\\').Trim();
+			inputPath = inputPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim();
 
 			// check for wildcards
 			if (inputPath.IndexOf('*') < 0)
@@ -40,9 +40,9 @@ namespace Leprechaun.Configuration
 			string rootDir = inputPath.Substring(0, wildcardIndex);
 
 			// handle partial wildcards e.g. Dir*
-			if (!rootDir.EndsWith("\\")) rootDir = rootDir.Substring(0, rootDir.LastIndexOf('\\'));
+			if (!rootDir.EndsWith($"{Path.DirectorySeparatorChar}")) rootDir = rootDir.Substring(0, rootDir.LastIndexOf(Path.DirectorySeparatorChar));
 
-			var wildcardSegments = new Queue<string>(inputPath.Substring(wildcardIndex).Split('\\'));
+			var wildcardSegments = new Queue<string>(inputPath.Substring(wildcardIndex).Split(Path.DirectorySeparatorChar));
 
 			var pathCandidates = new Queue<string>();
 			pathCandidates.Enqueue(rootDir);


### PR DESCRIPTION
This is a fix for issue #59. Switch from hard coded directory separators to system constants. I am having troubles getting the tests to run on my Mac right now, so I am unable to verify that I didn't break anything.