### PR TITLE
Multiple Leprechaun configurations in SCS JSON file

### DIFF
--- a/src/Leprechaun.InputProviders.Sitecore/Extensions/SerializationModuleConfigurationExtensions.cs
+++ b/src/Leprechaun.InputProviders.Sitecore/Extensions/SerializationModuleConfigurationExtensions.cs
@@ -3,19 +3,27 @@ using Sitecore.DevEx.Serialization.Client.Configuration;
 
 namespace Leprechaun.InputProviders.Sitecore.Extensions
 {
-	public static class SerializationModuleConfigurationExtensions
+	public static List<string> GetLeprechaunModuleName(this SerializationModuleConfiguration configuration)
 	{
-		public static string GetLeprechaunModuleName(this SerializationModuleConfiguration configuration)
+		if(configuration == null)
+			throw new NullReferenceException("SerializationModuleConfiguration is null");
+	 
+		List<string> configNames = new List<string>(); 
+		if (!configuration.Extensions.ContainsKey("leprechaun"))
+			return new List<string> { configuration.Namespace };
+		var token =	configuration.Extensions["leprechaun"].SelectToken("configuration"); 
+		if (token.Type == JTokenType.Array)
 		{
-			if(configuration == null)
-				throw new NullReferenceException("SerializationModuleConfiguration is null");
-
-			if (!configuration.Extensions.ContainsKey("leprechaun"))
-				return configuration.Namespace;
-
-			var configName = configuration.Extensions["leprechaun"].SelectToken("configuration").Value<string>("@name");
-
-			return string.IsNullOrEmpty(configName) ? configuration.Namespace : configName;
+			foreach (JToken item in token)
+			{
+				configNames.Add(item.Value<string>("@name"));
+			}
 		}
+		else
+		{
+			configNames.Add(token.Value<string>("@name"));
+		}			
+ 
+		return configNames ?? new List<string> { configuration.Namespace };
 	}
 }

--- a/src/Leprechaun.InputProviders.Sitecore/Extensions/SerializationModuleConfigurationExtensions.cs
+++ b/src/Leprechaun.InputProviders.Sitecore/Extensions/SerializationModuleConfigurationExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 using Sitecore.DevEx.Serialization.Client.Configuration;
 
 namespace Leprechaun.InputProviders.Sitecore.Extensions

--- a/src/Leprechaun.InputProviders.Sitecore/Extensions/SerializationModuleConfigurationExtensions.cs
+++ b/src/Leprechaun.InputProviders.Sitecore/Extensions/SerializationModuleConfigurationExtensions.cs
@@ -3,27 +3,30 @@ using Sitecore.DevEx.Serialization.Client.Configuration;
 
 namespace Leprechaun.InputProviders.Sitecore.Extensions
 {
-	public static List<string> GetLeprechaunModuleName(this SerializationModuleConfiguration configuration)
-	{
-		if(configuration == null)
-			throw new NullReferenceException("SerializationModuleConfiguration is null");
-	 
-		List<string> configNames = new List<string>(); 
-		if (!configuration.Extensions.ContainsKey("leprechaun"))
-			return new List<string> { configuration.Namespace };
-		var token =	configuration.Extensions["leprechaun"].SelectToken("configuration"); 
-		if (token.Type == JTokenType.Array)
+	public static class SerializationModuleConfigurationExtensions
+	{	
+		public static List<string> GetLeprechaunModuleName(this SerializationModuleConfiguration configuration)
 		{
-			foreach (JToken item in token)
+			if(configuration == null)
+				throw new NullReferenceException("SerializationModuleConfiguration is null");
+		 
+			List<string> configNames = new List<string>(); 
+			if (!configuration.Extensions.ContainsKey("leprechaun"))
+				return new List<string> { configuration.Namespace };
+			var token =	configuration.Extensions["leprechaun"].SelectToken("configuration"); 
+			if (token.Type == JTokenType.Array)
 			{
-				configNames.Add(item.Value<string>("@name"));
+				foreach (JToken item in token)
+				{
+					configNames.Add(item.Value<string>("@name"));
+				}
 			}
+			else
+			{
+				configNames.Add(token.Value<string>("@name"));
+			}			
+	 
+			return configNames ?? new List<string> { configuration.Namespace };
 		}
-		else
-		{
-			configNames.Add(token.Value<string>("@name"));
-		}			
- 
-		return configNames ?? new List<string> { configuration.Namespace };
 	}
 }

--- a/src/Leprechaun.InputProviders.Sitecore/ModuleConfigurationReader.cs
+++ b/src/Leprechaun.InputProviders.Sitecore/ModuleConfigurationReader.cs
@@ -65,13 +65,19 @@ namespace Leprechaun.InputProviders.Sitecore
 
 				Environment.Exit(1);
 			}
-
-
-			var moduleConfigurations = Task.Run(async () => await _serializationConfigurationManager.ReadSerializationConfiguration(resolveRootConfiguration.Result,
-				new ModuleGlobResolver(_loggerFactory.CreateLogger<ModuleGlobResolver>(), new ExternalPackageResolver(_loggerFactory)))); // TODO
-			moduleConfigurations.Wait();
-			
-			return _modules = moduleConfigurations.Result.ToDictionary(m => m.GetLeprechaunModuleName());
+   
+			var moduleConfigurations = Task.Run(async () => await _serializationConfigurationManager.ReadSerializationConfiguration(resolveRootConfiguration.Result, new ModuleGlobResolver(_loggerFactory.CreateLogger<ModuleGlobResolver>(), new ExternalPackageResolver(_loggerFactory)))); // TODO
+			moduleConfigurations.Wait(); 
+			var result = moduleConfigurations.Result;
+			foreach(var configuration in result)
+			{
+				List<string> modules = configuration.GetLeprechaunModuleName();
+				foreach(string module in modules)
+				{
+					_modules.Add(module, configuration);
+				}
+			}
+			return _modules;
 		}
 	}
 }

--- a/src/Leprechaun/MetadataGeneration/StandardTemplateMetadataGenerator.cs
+++ b/src/Leprechaun/MetadataGeneration/StandardTemplateMetadataGenerator.cs
@@ -92,10 +92,14 @@ namespace Leprechaun.MetadataGeneration
 		protected virtual void ApplyBaseTemplates(IList<ConfigurationCodeGenerationMetadata> generatedMetadata)
 		{
 			// index all templates' metadata (so we can resolve base template IDs)
-			var allTemplatesIndex = generatedMetadata
-				.SelectMany(config => config.Metadata)
-				.ToDictionary(template => template.Id);
-
+			var allTemplatesIndexes = generatedMetadata.SelectMany(config => config.Metadata);
+			var allTemplatesIndex = new Dictionary<Guid, TemplateCodeGenerationMetadata>();
+			foreach (TemplateCodeGenerationMetadata item in allTemplatesIndexes)
+			{
+				if (!allTemplatesIndex.ContainsKey(item.Id))
+					allTemplatesIndex.Add(item.Id, item);
+			}
+   
 			foreach (var config in generatedMetadata)
 			{
 				foreach (var template in config.Metadata)

--- a/src/Leprechaun/Validation/StandardArchitectureValidator.cs
+++ b/src/Leprechaun/Validation/StandardArchitectureValidator.cs
@@ -24,8 +24,13 @@ namespace Leprechaun.Validation
 
 		public void Validate(TemplateCodeGenerationMetadata[] allTemplates)
 		{
-			var allTemplatesIndex = allTemplates.ToDictionary(config => config.Id);
-
+			var allTemplatesIndex = new Dictionary<Guid, TemplateCodeGenerationMetadata>();
+			foreach (TemplateCodeGenerationMetadata item in allTemplates)
+			{
+				if (!allTemplatesIndex.ContainsKey(item.Id))
+					allTemplatesIndex.Add(item.Id, item);
+			}
+   
 			// ReSharper disable once ReplaceWithSingleAssignment.False
 			bool errors = false;
 


### PR DESCRIPTION
Multiple Leprechaun configurations in SCS JSON file
e.g.:

"leprechaun": {
    "configurations": [
        {
            "@extends": "Sample.Feature",
            "@name": "Feature.Sample"
        },
        {
            "@extends": "Sample.Feature.Builders",
            "@name": "Feature.Sample.Builders"
        }
    ]
  }